### PR TITLE
fix: repair broken YARA detections, missing click dep, and core import

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [master, dev, "feature/*", cli/*', test/*']
+    branches: [master, dev, "feature/*", "cli/*", "test/*"]
   pull_request:
     branches: [master, dev]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 
 # Core dependencies (always installed)
 dependencies = [
+    "click>=8.0.0",
     "scikit-learn>=1.2.0",
     "joblib>=1.5.0",
     "yara-python>=4.3.0",

--- a/rules/yara/apitokens.yar
+++ b/rules/yara/apitokens.yar
@@ -11,16 +11,16 @@ rule ContainsAPIToken
         $artifactory1 = /AP[\dABCDEF][a-zA-Z0-9]{8,}/
 
         $aws0 = /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/
-        $aws1 = /amzn\\.mws\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+        $aws1 = /amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
         $aws2 = /da2-[a-z0-9]{26}/
 
         $azure = /AZURE[A-Za-z0-9]{12}/
 
         $facebook = /EAACEdEose0cBA[0-9A-Za-z]+/
 
-        $google = /AIza[0-9A-Za-z\\-_]{35}/
-        $google_oauth = /ya29\\.[0-9A-Za-z\\-_]+/
-        $gcp_oauth = /[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com/
+        $google = /AIza[0-9A-Za-z_-]{35}/
+        $google_oauth = /ya29\.[0-9A-Za-z_-]+/
+        $gcp_oauth = /[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com/
 
         $linkedin = /linkedin(.{0,20})?['\"][0-9a-z]{16}/
 
@@ -29,16 +29,16 @@ rule ContainsAPIToken
         $mailgun = /key-[0-9a-zA-Z]{32}/
 
         $slack = /(xox[pborsa]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})/
-        $slack_webhook = /https:\/\/hooks\\.slack\\.com\/services\/T[a-zA-Z0-9_]{8}\/B[a-zA-Z0-9_]{8}\/[a-zA-Z0-9_]{24}/
+        $slack_webhook = /https:\/\/hooks\.slack\.com\/services\/T[a-zA-Z0-9_]{8}\/B[a-zA-Z0-9_]{8}\/[a-zA-Z0-9_]{24}/
 
         $stripe0 = /sk_live_[0-9a-zA-Z]{24}/
         $stripe1 = /rk_live_[0-9a-zA-Z]{24}/
 
-        $square0 = /sqOatp-[0-9A-Za-z\\-_]{22}/
+        $square0 = /sqOatp-[0-9A-Za-z_-]{22}/
 
-        $square1 = /sq0csp-[ 0-9A-Za-z\\-_]{43}/
+        $square1 = /sq0csp-[ 0-9A-Za-z_-]{43}/
 
-        $telegram = /[0-9]+:AA[0-9A-Za-z\\-_]{33}/
+        $telegram = /[0-9]+:AA[0-9A-Za-z_-]{33}/
         $twilio = /SK[0-9a-fA-F]{32}/
 
     condition:

--- a/rules/yara/instruction_bypass.yar
+++ b/rules/yara/instruction_bypass.yar
@@ -6,7 +6,7 @@ rule InstructionBypass: Injection
         author = "Adam M. Swanda"
 
     strings:
-        $bypass_phrase = /(Ignore|Disregard|Skip|Forget|Neglect|Overlook|Omit|Bypass|Pay no attention to|Do not follow|Do not obey)\s*(prior|previous|preceding|above|foregoing|earlier|initial)?\s*(content|text|instructions|instruction|directives|directive|commands|command|context|conversation|input|inputs|data|message|messages|communication|response|responses|request|requests)\s*(and start over|and start anew|and begin afresh|and start from scratch)?/
+        $bypass_phrase = /(Ignore|Disregard|Skip|Forget|Neglect|Overlook|Omit|Bypass|Pay no attention to|Do not follow|Do not obey)\s*(all|the|any|my|your|these|those|our)?\s*(prior|previous|preceding|above|foregoing|earlier|initial)?\s*(content|text|instructions|instruction|directives|directive|commands|command|context|conversation|input|inputs|data|message|messages|communication|response|responses|request|requests)\s*(and start over|and start anew|and begin afresh|and start from scratch)?/ nocase
     condition:
         $bypass_phrase
 }

--- a/rules/yara/ip.yar
+++ b/rules/yara/ip.yar
@@ -1,12 +1,13 @@
-rule InstructionBypass: Injection
+rule ContainsIPAddress
 {
     meta:
-        category = "Instruction Bypass"
-        description = "Detects phrases used to ignore, disregard, or bypass instructions."
-        author = "Adam M. Swanda"
+        category = "Sensitive Data"
+        description = "Detects IPv4 and IPv6 addresses in a prompt, which may indicate exfiltration targets, C2 endpoints, or internal network disclosure"
 
     strings:
-        $bypass_phrase = /(Ignore|Disregard|Skip|Forget|Neglect|Overlook|Omit|Bypass|Pay no attention to|Do not follow|Do not obey)\s*(prior|previous|preceding|above|foregoing|earlier|initial)?\s*(content|text|instructions|instruction|directives|directive|commands|command|context|conversation|input|inputs|data|message|messages|communication|response|responses|request|requests)\s*(and start over|and start anew|and begin afresh|and start from scratch)?/
+        $ipv4 = /\b(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b/
+        $ipv6 = /\b([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}\b/
+
     condition:
-        $bypass_phrase
+        any of them
 }

--- a/src/promptscreen/data/rules/apitokens.yar
+++ b/src/promptscreen/data/rules/apitokens.yar
@@ -11,16 +11,16 @@ rule ContainsAPIToken
         $artifactory1 = /AP[\dABCDEF][a-zA-Z0-9]{8,}/
 
         $aws0 = /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/
-        $aws1 = /amzn\\.mws\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+        $aws1 = /amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
         $aws2 = /da2-[a-z0-9]{26}/
 
         $azure = /AZURE[A-Za-z0-9]{12}/
 
         $facebook = /EAACEdEose0cBA[0-9A-Za-z]+/
 
-        $google = /AIza[0-9A-Za-z\\-_]{35}/
-        $google_oauth = /ya29\\.[0-9A-Za-z\\-_]+/
-        $gcp_oauth = /[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com/
+        $google = /AIza[0-9A-Za-z_-]{35}/
+        $google_oauth = /ya29\.[0-9A-Za-z_-]+/
+        $gcp_oauth = /[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com/
 
         $linkedin = /linkedin(.{0,20})?['\"][0-9a-z]{16}/
 
@@ -29,16 +29,16 @@ rule ContainsAPIToken
         $mailgun = /key-[0-9a-zA-Z]{32}/
 
         $slack = /(xox[pborsa]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})/
-        $slack_webhook = /https:\/\/hooks\\.slack\\.com\/services\/T[a-zA-Z0-9_]{8}\/B[a-zA-Z0-9_]{8}\/[a-zA-Z0-9_]{24}/
+        $slack_webhook = /https:\/\/hooks\.slack\.com\/services\/T[a-zA-Z0-9_]{8}\/B[a-zA-Z0-9_]{8}\/[a-zA-Z0-9_]{24}/
 
         $stripe0 = /sk_live_[0-9a-zA-Z]{24}/
         $stripe1 = /rk_live_[0-9a-zA-Z]{24}/
 
-        $square0 = /sqOatp-[0-9A-Za-z\\-_]{22}/
+        $square0 = /sqOatp-[0-9A-Za-z_-]{22}/
 
-        $square1 = /sq0csp-[ 0-9A-Za-z\\-_]{43}/
+        $square1 = /sq0csp-[ 0-9A-Za-z_-]{43}/
 
-        $telegram = /[0-9]+:AA[0-9A-Za-z\\-_]{33}/
+        $telegram = /[0-9]+:AA[0-9A-Za-z_-]{33}/
         $twilio = /SK[0-9a-fA-F]{32}/
 
     condition:

--- a/src/promptscreen/data/rules/instruction_bypass.yar
+++ b/src/promptscreen/data/rules/instruction_bypass.yar
@@ -6,7 +6,7 @@ rule InstructionBypass: Injection
         author = "Adam M. Swanda"
 
     strings:
-        $bypass_phrase = /(Ignore|Disregard|Skip|Forget|Neglect|Overlook|Omit|Bypass|Pay no attention to|Do not follow|Do not obey)\s*(prior|previous|preceding|above|foregoing|earlier|initial)?\s*(content|text|instructions|instruction|directives|directive|commands|command|context|conversation|input|inputs|data|message|messages|communication|response|responses|request|requests)\s*(and start over|and start anew|and begin afresh|and start from scratch)?/
+        $bypass_phrase = /(Ignore|Disregard|Skip|Forget|Neglect|Overlook|Omit|Bypass|Pay no attention to|Do not follow|Do not obey)\s*(all|the|any|my|your|these|those|our)?\s*(prior|previous|preceding|above|foregoing|earlier|initial)?\s*(content|text|instructions|instruction|directives|directive|commands|command|context|conversation|input|inputs|data|message|messages|communication|response|responses|request|requests)\s*(and start over|and start anew|and begin afresh|and start from scratch)?/ nocase
     condition:
         $bypass_phrase
 }

--- a/src/promptscreen/data/rules/ip.yar
+++ b/src/promptscreen/data/rules/ip.yar
@@ -1,12 +1,13 @@
-rule InstructionBypass: Injection
+rule ContainsIPAddress
 {
     meta:
-        category = "Instruction Bypass"
-        description = "Detects phrases used to ignore, disregard, or bypass instructions."
-        author = "Adam M. Swanda"
+        category = "Sensitive Data"
+        description = "Detects IPv4 and IPv6 addresses in a prompt, which may indicate exfiltration targets, C2 endpoints, or internal network disclosure"
 
     strings:
-        $bypass_phrase = /(Ignore|Disregard|Skip|Forget|Neglect|Overlook|Omit|Bypass|Pay no attention to|Do not follow|Do not obey)\s*(prior|previous|preceding|above|foregoing|earlier|initial)?\s*(content|text|instructions|instruction|directives|directive|commands|command|context|conversation|input|inputs|data|message|messages|communication|response|responses|request|requests)\s*(and start over|and start anew|and begin afresh|and start from scratch)?/
+        $ipv4 = /\b(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b/
+        $ipv6 = /\b([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}\b/
+
     condition:
-        $bypass_phrase
+        any of them
 }

--- a/src/promptscreen/utils/__init__.py
+++ b/src/promptscreen/utils/__init__.py
@@ -1,6 +1,17 @@
 """Utility functions and classes."""
 
-from .query_agent import QueryAgent
 from .text_preprocessor import TextPreProcessor
+
+# QueryAgent requires langchain-ollama, which is only installed via the
+# `eval`/`all` extras. Importing it must not break a core-only install,
+# since core guards (e.g. JailbreakInferenceAPI) depend on this package
+# for TextPreProcessor.
+try:
+    from .query_agent import QueryAgent
+
+    _has_query_agent = True
+except ImportError:
+    QueryAgent = None  # type: ignore
+    _has_query_agent = False
 
 __all__ = ["QueryAgent", "TextPreProcessor"]


### PR DESCRIPTION
- Declare click as a core dependency; the promptscreen CLI entry point required it but it wasn't listed anywhere, so a clean `pip install promptscreen` produced a broken CLI (ModuleNotFoundError).
- Fix apitokens.yar: several patterns (Google API key/OAuth, GCP OAuth client ID, AWS MWS token, Slack webhook) used doubly-escaped dots (\\.) which YARA parses as literal-backslash-then-any-char instead of an escaped dot, so these credential patterns never matched real tokens.
- Fix instruction_bypass.yar: the bypass-phrase regex had no `nocase` modifier and required the qualifier word to immediately follow the verb, so it missed lowercase "ignore" and filler words ("ignore all previous instructions", "ignore the previous instructions") - arguably the most common phrasing of this attack.
- Replace ip.yar, which was a byte-for-byte copy/paste of instruction_bypass.yar's rule, with an actual IPv4/IPv6 detection rule.
- Apply the same fixes to the packaged rule copies under src/promptscreen/data/rules/ (kept in sync with rules/yara/).
- Fix promptscreen/utils/__init__.py eagerly importing QueryAgent, which requires langchain-ollama (an eval-only extra). This made `import promptscreen` fail on a core-only install, since defence/linear_svm.py (a core guard) transitively imports this package for TextPreProcessor. QueryAgent now degrades to None when langchain-ollama isn't installed, matching the optional-dependency pattern used elsewhere in the codebase.

Verified in an isolated core-only virtualenv (only declared core deps): package now imports cleanly and the full test suite passes (150/150 with eval/api extras installed, 40/40 relevant tests with core deps only).